### PR TITLE
DartRespawnBugFixes

### DIFF
--- a/Assets/Scenes/GameModeTimeTrial.unity
+++ b/Assets/Scenes/GameModeTimeTrial.unity
@@ -418,6 +418,14 @@ PrefabInstance:
       propertyPath: DartBoard
       value: 
       objectReference: {fileID: 2117294225}
+    - target: {fileID: 1334826080, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
+      propertyPath: DartBoard
+      value: 
+      objectReference: {fileID: 2117294225}
+    - target: {fileID: 1334826080, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
+      propertyPath: dartCounterText
+      value: 
+      objectReference: {fileID: 1089396529}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
 --- !u!1 &126753658
@@ -2665,6 +2673,14 @@ PrefabInstance:
       propertyPath: MainCamera
       value: 
       objectReference: {fileID: 7}
+    - target: {fileID: 1334826080, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
+      propertyPath: dartCounterText
+      value: 
+      objectReference: {fileID: 1089396529}
+    - target: {fileID: 1334826080, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
+      propertyPath: DartBoard
+      value: 
+      objectReference: {fileID: 2117294225}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 91238cbd070704be284f16c89436bd6b, type: 3}
 --- !u!1 &1742071814 stripped

--- a/Assets/Scripts/ThrowRealDart.cs
+++ b/Assets/Scripts/ThrowRealDart.cs
@@ -57,6 +57,7 @@ public class ThrowRealDart : MonoBehaviour
 
             transform.SetParent(DartBoard.transform);
             transform.localScale = new Vector3(80, 80, 80);
+            scene = SceneManager.GetActiveScene();
             if (scene.name == "GameModeModern")
             {
                 if (col.gameObject.name == "InnerBoard")
@@ -97,7 +98,8 @@ public class ThrowRealDart : MonoBehaviour
         // The new dart must be changed back to "Dart" tag from "InactiveDart" as assigned in PointsAssigner.cs
         dartCpy.gameObject.tag = "Dart";
         print(scene.name);
-        if (scene.name == "GameModeModern")
+        scene = SceneManager.GetActiveScene();
+        if (scene.name == "GameModeModern" || scene.name == "GameModeTimeTrial")
         {
             print("check");
             Destroy(this.gameObject);


### PR DESCRIPTION
Darts would behave strangely because the scene name was only updated in the Start call of ThrowRealDart. Public GameObject links were missing on the darts in TimeTrial mode.